### PR TITLE
TypeScript: don't use outfile with tsc - it does not support modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf coverage tmp",
     "versioning": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "prebuild": "npm run clean; npm run versioning; npm run lint",
-    "dts": "tsc ./src/index.ts --declaration --emitDeclarationOnly --esModuleInterop --downlevelIteration --outfile ./dist/index.d.ts",
+    "dts": "tsc ./src/index.ts --declaration --emitDeclarationOnly --esModuleInterop --downlevelIteration --outdir ./dist",
     "build:esm": "esbuild ./src/index.ts --tsconfig=tsconfig.modules.json --minify --bundle --sourcemap --target=node12.22.5 --platform=node --format=esm --outfile=./dist/esm/index.js --external:keyv --external:keyv-file --external:eventsource --external:axios",
     "build:cjs": "esbuild ./src/index.ts --tsconfig=tsconfig.release.json --minify --bundle --sourcemap --target=node12.22.5 --platform=node --format=cjs --outfile=./dist/cjs/index.js --external:keyv --external:keyv-file --external:eventsource --external:axios",
     "build": "npm run build:esm; npm run build:cjs; npm run dts",


### PR DESCRIPTION
Installing `@harnessio/ff-nodejs-server-sdk` and importing it in a typescript project results in a typescript error[1]. The is caused by this package being built with `tsc --outfile` which is [not supposed to be used](https://www.typescriptlang.org/tsconfig/#outFile) with module files and should only be used for libraries which expose global variables. 

To reproduce the error, check out  [kdojeteri/harness-ff-typescript-error](https://github.com/kdojeteri/harness-ff-typescript-error).

This pull request removes the `--outfile ./dist/index.d.ts` parameter and replaces it with `--outdir ./dist`, which fixes the error.

[1]
```
$ tsc --noEmit
index.ts:1:32 - error TS2306: File '/Users/figure/Desktop/test/node_modules/@harnessio/ff-nodejs-server-sdk/dist/index.d.ts' is not a module.

1 import { Client, Logger } from '@harnessio/ff-nodejs-server-sdk'
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 1 error.
error Command failed with exit code 2.
```